### PR TITLE
Cache velocity data

### DIFF
--- a/frontend/js/vector.js
+++ b/frontend/js/vector.js
@@ -6,7 +6,7 @@ var mapboxTiles = L.tileLayer('https://{s}.tiles.mapbox.com/v3/tabs-enthought.j3
 var delay = 90;                 // speed of animation (larger is slower)
 var vectorGroup = L.layerGroup([]); // global layer to update vector multiPolylines
 var isRunning = true;
-var points = [];
+var points = [];		// global lat/lon pairs of point locations
 var nSteps = 90;                // number of time steps to use
 var velocities = [];		// cache of velocity data
 


### PR DESCRIPTION
Avoid reading the velocity JSON data after the first time through by caching it in memory.

Also cleans up tabs to spaces in js file.
