### PR TITLE
Scale vectors with zoom level

### DIFF
--- a/frontend/js/vector.js
+++ b/frontend/js/vector.js
@@ -6,10 +6,10 @@ var mapboxTiles = L.tileLayer('https://{s}.tiles.mapbox.com/v3/tabs-enthought.j3
 var delay = 90;                 // speed of animation (larger is slower)
 var vectorGroup = L.layerGroup([]); // global layer to update vector multiPolylines
 var isRunning = true;
-var points = [];		// global lat/lon pairs of point locations
+var points = [];                // global lat/lon pairs of point locations
 var nSteps = 90;                // number of time steps to use
-var velocities = [];		// cache of velocity data
-var defaultZoom = 7;		// initial zoom level
+var velocities = [];                // cache of velocity data
+var defaultZoom = 7;                // initial zoom level
 
 var map = L.map('map')
     .addLayer(mapboxTiles)
@@ -68,7 +68,7 @@ function showTimeStep(j) {
     var layer = vectorGroup.getLayers()[0];
     if (velocities[j] == undefined) {
         $.getJSON('json_data/step' + j + '.json', function(json) {
-	    velocities[j] = json;
+            velocities[j] = json;
             layer.setLatLngs(getVectors(points, json));
         });
     } else {


### PR DESCRIPTION
Set the vector scale dependent on zoom level.

Closes #3.  Does not address density of arrows (#7).

Note that this is against the `enh/scale-with-zoom` branch, which is the branch for #10.
