### PR TITLE
Only visualize vectors by default

### DIFF
--- a/static/js/Config.js
+++ b/static/js/Config.js
@@ -47,8 +47,8 @@ var Config = {
 
     // Which data is shown by default?
     display: {
-        velocity: false,
-        salinity: true
+        velocity: true,
+        salinity: false
     }
 
 };


### PR DESCRIPTION
Scalar contours are working, but currently a bit slow.  Make displaying vectors the default.

This should have user-facing controls to click on/off.
