### PR TITLE
Resample vectors points by zoom level

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ from tabs import thredds_frame_source
 
 app = Flask(__name__)
 
+DECIMATE_FACTOR = 10
 RANDOM_STATE = np.random.get_state()
 
 
@@ -75,7 +76,7 @@ class THREDDS_CONNECTION(object):
 
 
 tc = THREDDS_CONNECTION(data_uri=thredds_frame_source.DEFAULT_DATA_URI,
-                        decimate_factor=60)
+                        decimate_factor=DECIMATE_FACTOR)
 
 
 def jsonify_dict_of_array(obj):

--- a/static/js/Config.js
+++ b/static/js/Config.js
@@ -13,6 +13,7 @@ var Config = {
     barbDescriptions: {tail: 0, center: 0.5, head: 1.0},
     arrowHeadSize: 0.15,
     arrowHeadAngle: 60,
+    vectorDensity: 500,
 
     // Contour style
     contourOptions: {

--- a/static/js/Config.js
+++ b/static/js/Config.js
@@ -62,7 +62,7 @@ var Config = {
     },
 
     // Which data is shown by default?
-    display: {
+    visibleLayers: {
         velocity: true,
         salinity: false
     }

--- a/static/js/Config.js
+++ b/static/js/Config.js
@@ -36,6 +36,7 @@ var Config = {
     minZoom: 7,
     defaultZoom: 7,
     maxZoom: 11,
+    mapCenter: [26.946556420812623, -92.8289794921875],
 
     // Pause between frames (in ms)
     delay: 90,

--- a/static/js/MapView.js
+++ b/static/js/MapView.js
@@ -17,6 +17,7 @@ MapView = (function($, L, Models, Config) {
         minZoom: Config.minZoom,
         defaultZoom: Config.defaultZoom,
         maxZoom: Config.maxZoom,
+        mapCenter: Config.mapCenter,
 
         tileLayerURL: Config.tileLayerURL,
 
@@ -43,7 +44,7 @@ MapView = (function($, L, Models, Config) {
         });
 
         // Leaflet map object
-        this.map = L.map('map', {center: [27, -94],
+        this.map = L.map('map', {center: self.mapCenter,
                                  zoom: self.defaultZoom,
                                  layers: [mapboxTiles]});
 

--- a/static/js/MapView.js
+++ b/static/js/MapView.js
@@ -67,6 +67,17 @@ MapView = (function($, L, Models, Config) {
         self.distanceScaleControl = L.control.scale(
             Config.distanceScaleOptions).addTo(self.map);
 
+        // Add layer selector and hook up toggling of visibility flag
+        var lsc = self.layerSelectControl = L.control.layers([], [],
+            {position: 'topleft'}).addTo(self.map);
+        lsc.addToggledOverlay = function addToggledOverlay(key, layer, name) {
+            lsc.addOverlay(layer, name);
+            self.map.on(
+                'overlayadd', _setLayerVisibility(self, key, layer, true));
+            self.map.on(
+                'overlayremove', _setLayerVisibility(self, key, layer, false));
+        };
+
         // Add visualization layers
         self.saltView = SaltView.saltView(config).addTo(self);
         self.velocityView = VelocityView.velocityView(config).addTo(self);
@@ -176,6 +187,19 @@ MapView = (function($, L, Models, Config) {
 
     return {
         mapView: function mapView(config) { return new MapView(config); }
+    };
+
+
+    // Private functions
+
+    function _setLayerVisibility(mapView, key, layer, value) {
+        function setLayerVisibilityInner(e) {
+            if (e.layer === layer) {
+                mapView.visibleLayers[key] = value;
+                mapView.redraw();
+            }
+        }
+        return setLayerVisibilityInner;
     };
 
 }(jQuery, L, Models, Config));

--- a/static/js/MapView.js
+++ b/static/js/MapView.js
@@ -2,7 +2,7 @@ MapView = (function($, L, Models, Config) {
 
     var defaults = {
 
-        display: Config.display,
+        visibleLayers: Config.visibleLayers,
 
         // Speed of animation (larger is slower)
         delay: Config.delay,
@@ -70,11 +70,11 @@ MapView = (function($, L, Models, Config) {
 
 
         // Add visualization layers
-        if (self.display.velocity) {
+        if (self.visibleLayers.velocity) {
             self.velocityView = VelocityView.velocityView(config).addTo(self);
         }
 
-        if (self.display.salinity) {
+        if (self.visibleLayers.salinity) {
             self.saltView = SaltView.saltView(config).addTo(self);
         }
 
@@ -158,7 +158,7 @@ MapView = (function($, L, Models, Config) {
     MapView.prototype.redraw = function redraw(callback) {
         var self = this;
 
-        if (this.display.velocity) {
+        if (this.visibleLayers.velocity) {
             this.velocityView && this.velocityView.redraw(
                 function vv_call(data) {
                     self.tabsControl && self.tabsControl.updateInfo(
@@ -168,7 +168,7 @@ MapView = (function($, L, Models, Config) {
             );
         }
 
-        if (this.display.salinity) {
+        if (this.visibleLayers.salinity) {
             this.saltView && this.saltView.redraw(
                 function salt_call(data) {
                     self.tabsControl && self.tabsControl.updateInfo(

--- a/static/js/MapView.js
+++ b/static/js/MapView.js
@@ -65,18 +65,11 @@ MapView = (function($, L, Models, Config) {
         self.tabsControl.addTo(self.map);
 
         self.distanceScaleControl = L.control.scale(
-            Config.distanceScaleOptions);
-        self.distanceScaleControl.addTo(self.map);
-
+            Config.distanceScaleOptions).addTo(self.map);
 
         // Add visualization layers
-        if (self.visibleLayers.velocity) {
-            self.velocityView = VelocityView.velocityView(config).addTo(self);
-        }
-
-        if (self.visibleLayers.salinity) {
-            self.saltView = SaltView.saltView(config).addTo(self);
-        }
+        self.saltView = SaltView.saltView(config).addTo(self);
+        self.velocityView = VelocityView.velocityView(config).addTo(self);
 
         self.redraw();
 

--- a/static/js/SaltView.js
+++ b/static/js/SaltView.js
@@ -32,10 +32,12 @@ var SaltView = (function($, L, Models, Config) {
 
         this.mapView = mapView;
 
-        // Put the initial contours on the map
-        this.redraw(function initialCallback() {
+        mapView.layerSelectControl.addToggledOverlay(
+            'salinity', self.saltGroup, 'Salinity');
+
+        if (self.mapView.visibleLayers.salinity) {
             self.saltGroup.addTo(mapView.map);
-        });
+        }
 
         return this;
     };

--- a/static/js/VelocityView.js
+++ b/static/js/VelocityView.js
@@ -51,7 +51,9 @@ var VelocityView = (function($, L, Models, Config) {
     VelocityView.prototype.addTo = function addTo(mapView) {
         var self = this;
 
-        this.mapView = mapView;
+        self.mapView = mapView;
+
+        self.mapView.map.on('dragend', function() {self.redraw()});
 
         mapView.layerSelectControl.addToggledOverlay(
             'velocity', self.vectorGroup, 'Velocity');

--- a/static/js/VelocityView.js
+++ b/static/js/VelocityView.js
@@ -5,6 +5,9 @@ var VelocityView = (function($, L, Models, Config) {
         // layer containing currently displayed vector polylines
         vectorGroup: L.layerGroup([]),
 
+        // The number of vectors to display
+        displayPoints: 0,
+
         // Collection of all vector polylines
         allVectors: [],
 

--- a/static/js/VelocityView.js
+++ b/static/js/VelocityView.js
@@ -103,9 +103,10 @@ var VelocityView = (function($, L, Models, Config) {
         self.vfs.withVelocityFrame(options, function(data) {
             var old = self.displayPoints;
             self.updateDisplayPoints();
-            selectVectors(
-                self.displayPoints, old, self.allVectors, self.vectorGroup);
-            drawVectors(data, self.vectorGroup);
+            var latLngBounds = self.mapView.map.getBounds();
+            selectVectors(latLngBounds, self.displayPoints, old,
+                          self.allVectors, self.vectorGroup);
+            drawVectors(latLngBounds, data, self.vectorGroup);
             callback && callback(data);
         });
     };
@@ -134,22 +135,29 @@ var VelocityView = (function($, L, Models, Config) {
     // Private Functions
 
     function selectVectors(
-            displayPoints, oldDisplayPoints, allVectors, vectorGroup) {
+            latLngBounds, displayPoints, oldDisplayPoints,
+            allVectors, vectorGroup) {
         if (displayPoints > oldDisplayPoints) {
+            // console.log(oldDisplayPoints + ' -> ' + displayPoints);
             allVectors.slice(oldDisplayPoints, displayPoints)
-                      .forEach(vectorGroup.addLayer.bind(vectorGroup));
+                .forEach(vectorGroup.addLayer.bind(vectorGroup));
         } else if (displayPoints < oldDisplayPoints) {
+            // console.log(oldDisplayPoints + ' -> ' + displayPoints);
             allVectors.slice(displayPoints, oldDisplayPoints)
                 .forEach(vectorGroup.removeLayer.bind(vectorGroup));
         }
     }
 
 
-    function drawVectors(velocityFrames, vectorGroup) {
+    function drawVectors(latLngBounds, velocityFrames, vectorGroup) {
         var latLngs = velocityFrames.vectors;
+        var i = 0;
         vectorGroup.eachLayer(function _redraw(layer) {
-            layer.setLatLngs(latLngs[this.i++]);
-        }, {i: 0});
+            var idx = i++;
+            if (latLngBounds.intersects(layer.getBounds())) {
+                layer.setLatLngs(latLngs[idx]);
+            }
+        });
     }
 
 }(jQuery, L, Models, Config));

--- a/static/js/VelocityView.js
+++ b/static/js/VelocityView.js
@@ -2,8 +2,11 @@ var VelocityView = (function($, L, Models, Config) {
 
     var defaults = {
 
-        // layer containing vector polylines
+        // layer containing currently displayed vector polylines
         vectorGroup: L.layerGroup([]),
+
+        // Collection of all vector polylines
+        allVectors: [],
 
         // The locations of the data points
         points: [],
@@ -16,6 +19,9 @@ var VelocityView = (function($, L, Models, Config) {
 
         // Degrees!
         arrowHeadAngle: Config.arrowHeadAngle,
+
+        // Number of vectors at full zoom
+        vectorDensity: Config.vectorDensity,
 
         // Vector artist parameters
         color: 'black',
@@ -67,9 +73,13 @@ var VelocityView = (function($, L, Models, Config) {
                 var vectors = data.vectors;
                 for (var i = 0; i < vectors.length; i++) {
                     var line = L.polyline(vectors[i], style);
-                    self.vectorGroup.addLayer(line);
+                    self.allVectors.push(line);
                 }
             });
+
+            // Put the initial velocity vectors on the map
+            self.redraw();
+
         });
 
         return this;
@@ -88,9 +98,24 @@ var VelocityView = (function($, L, Models, Config) {
                        points: self.points,
                        mapScale: self.mapView.mapScale()};
         self.vfs.withVelocityFrame(options, function(data) {
+            self.updateDisplayPoints();
+            selectVectors(self.displayPoints, self.allVectors, self.vectorGroup);
             drawVectors(data, self.vectorGroup);
             callback && callback(data);
         });
+    };
+
+
+    VelocityView.prototype.updateDisplayPoints = function updateDisplayPts() {
+        var self = this;
+        var density = self.vectorDensity;
+        var nPoints = self.points.length;
+        var zoom = self.mapView.map.getZoom();
+        var minZoom = self.mapView.minZoom;
+        var scale = Math.pow(4, zoom - minZoom);
+        var n = Math.min(Math.ceil(density * scale), nPoints);
+        console.log('show', n, 'at zoom level', zoom);
+        self.displayPoints = n;
     };
 
 
@@ -103,13 +128,19 @@ var VelocityView = (function($, L, Models, Config) {
 
     // Private Functions
 
-    function drawVectors(data, lines) {
-        if (lines) {
-            lines.eachLayer(function _redraw(layer) {
-                layer.setLatLngs(this.latLngs[this.i++]);
-            }, {latLngs: data.vectors, i: 0});
-        }
+    function selectVectors(displayPoints, allVectors, vectorGroup) {
+        allVectors.slice(0, displayPoints)
+                  .forEach(vectorGroup.addLayer.bind(vectorGroup));
+        allVectors.slice(displayPoints)
+                  .forEach(vectorGroup.removeLayer.bind(vectorGroup));
     }
 
+
+    function drawVectors(velocityFrames, vectorGroup) {
+        var latLngs = velocityFrames.vectors;
+        vectorGroup.eachLayer(function _redraw(layer) {
+            layer.setLatLngs(latLngs[this.i++]);
+        }, {i: 0});
+    }
 
 }(jQuery, L, Models, Config));

--- a/static/js/VelocityView.js
+++ b/static/js/VelocityView.js
@@ -101,8 +101,10 @@ var VelocityView = (function($, L, Models, Config) {
                        points: self.points,
                        mapScale: self.mapView.mapScale()};
         self.vfs.withVelocityFrame(options, function(data) {
+            var old = self.displayPoints;
             self.updateDisplayPoints();
-            selectVectors(self.displayPoints, self.allVectors, self.vectorGroup);
+            selectVectors(
+                self.displayPoints, old, self.allVectors, self.vectorGroup);
             drawVectors(data, self.vectorGroup);
             callback && callback(data);
         });
@@ -131,11 +133,15 @@ var VelocityView = (function($, L, Models, Config) {
 
     // Private Functions
 
-    function selectVectors(displayPoints, allVectors, vectorGroup) {
-        allVectors.slice(0, displayPoints)
-                  .forEach(vectorGroup.addLayer.bind(vectorGroup));
-        allVectors.slice(displayPoints)
-                  .forEach(vectorGroup.removeLayer.bind(vectorGroup));
+    function selectVectors(
+            displayPoints, oldDisplayPoints, allVectors, vectorGroup) {
+        if (displayPoints > oldDisplayPoints) {
+            allVectors.slice(oldDisplayPoints, displayPoints)
+                      .forEach(vectorGroup.addLayer.bind(vectorGroup));
+        } else if (displayPoints < oldDisplayPoints) {
+            allVectors.slice(displayPoints, oldDisplayPoints)
+                .forEach(vectorGroup.removeLayer.bind(vectorGroup));
+        }
     }
 
 

--- a/static/js/VelocityView.js
+++ b/static/js/VelocityView.js
@@ -122,7 +122,7 @@ var VelocityView = (function($, L, Models, Config) {
         var minZoom = self.mapView.minZoom;
         var scale = Math.pow(4, zoom - minZoom);
         var n = Math.min(Math.ceil(density * scale), nPoints);
-        console.log('show', n, 'at zoom level', zoom);
+        // console.log('show', n, 'at zoom level', zoom);
         self.displayPoints = n;
     };
 

--- a/static/js/VelocityView.js
+++ b/static/js/VelocityView.js
@@ -58,12 +58,12 @@ var VelocityView = (function($, L, Models, Config) {
         }
 
         var style = {
-            color: this.color,
-            weight: this.weight
+            color: self.color,
+            weight: self.weight
         };
 
-        // put the initial velocity vectors on the map
-        this.vfs.withVelocityGridLocations({}, function(points) {
+        // Build the set of vectors to display
+        self.vfs.withVelocityGridLocations({}, function(points) {
             self.points = points;
 
             var options = {frame: mapView.currentFrame,
@@ -82,7 +82,7 @@ var VelocityView = (function($, L, Models, Config) {
 
         });
 
-        return this;
+        return self;
     };
 
 

--- a/static/js/VelocityView.js
+++ b/static/js/VelocityView.js
@@ -44,6 +44,13 @@ var VelocityView = (function($, L, Models, Config) {
 
         this.mapView = mapView;
 
+        mapView.layerSelectControl.addToggledOverlay(
+            'velocity', self.vectorGroup, 'Velocity');
+
+        if (self.mapView.visibleLayers.velocity) {
+            self.vectorGroup.addTo(mapView.map);
+        }
+
         var style = {
             color: this.color,
             weight: this.weight
@@ -62,7 +69,6 @@ var VelocityView = (function($, L, Models, Config) {
                     var line = L.polyline(vectors[i], style);
                     self.vectorGroup.addLayer(line);
                 }
-                self.vectorGroup.addTo(mapView.map);
             });
         });
 


### PR DESCRIPTION
This is a second attempt at changing the number of vectors shown by adapting #49 with some of the ideas discussed in it. I based it off of #50 , though, to make sure it will work in that context and to avoid the giant merge conflict that is otherwise inevitable between the two. Make sure #50 goes in first.

It appears to work pretty well, including with the layer selector, but it has some pretty serious garbage collection problems. I haven't dug through it but a quick run through the profiler has it spending literally half it's cpu time in GC.

That said, my hunch is that it's related to the drawing optimizations and could be cleaned up by avoiding calls to things like `Array.slice`. Even so, it almost runs at full speed, even in the middle zoom levels, which is where the number of visible vectors is greatest.

Closes #7.