### PR TITLE
Add command line args to configure the server

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import json
 from threading import Timer, RLock
+import sys
 
 import numpy as np
 from flask import Flask, redirect, request, url_for
@@ -145,4 +146,11 @@ def thredds_salt_frame(time_step):
     return json.dumps(salt)
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-p', '--port', default=5000, help="Port to listen on")
+    parser.add_argument('-a', '--all', dest='host', action='store_const',
+                        default='127.0.0.1', const='0.0.0.0',
+                        help="Listen on all interfaces")
+    args = parser.parse_args()
+    app.run(debug=True, host=args.host, port=args.port)

--- a/app.py
+++ b/app.py
@@ -148,9 +148,16 @@ def thredds_salt_frame(time_step):
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser()
-    parser.add_argument('-p', '--port', default=5000, help="Port to listen on")
+    parser.add_argument('-p', '--port', type=int, default=5000,
+                        help="Port to listen on")
     parser.add_argument('-a', '--all', dest='host', action='store_const',
                         default='127.0.0.1', const='0.0.0.0',
                         help="Listen on all interfaces")
+    parser.add_argument('-d', '--decimate', type=int, action='store',
+                        default=60, help="Decimation factor")
+
     args = parser.parse_args()
+    if args.decimate:
+        tc._fs_args['decimate_factor'] = args.decimate
+        del tc.fs
     app.run(debug=True, host=args.host, port=args.port)

--- a/app.py
+++ b/app.py
@@ -1,6 +1,5 @@
 import json
 from threading import Timer, RLock
-import sys
 
 import numpy as np
 from flask import Flask, redirect, request, url_for

--- a/app.py
+++ b/app.py
@@ -154,9 +154,11 @@ if __name__ == '__main__':
                         help="Listen on all interfaces")
     parser.add_argument('-d', '--decimate', type=int, action='store',
                         default=60, help="Decimation factor")
+    parser.add_argument('-D', '--debug', action='store_true',
+                        help="Debug mode")
 
     args = parser.parse_args()
     if args.decimate:
         tc._fs_args['decimate_factor'] = args.decimate
         del tc.fs
-    app.run(debug=True, host=args.host, port=args.port)
+    app.run(debug=args.debug, host=args.host, port=args.port)


### PR DESCRIPTION
`python app.py -p 5001 -d 20 -a`  will listen on all interfaces on port 5001 and decimate the data by a factor of 20 instead of current the default of `localhost:5000` with decimation 60.