### PR TITLE
Don't waste CPU when not visible

### DIFF
--- a/static/js/MapView.js
+++ b/static/js/MapView.js
@@ -130,9 +130,9 @@ MapView = (function($, L, Models, Config) {
     MapView.prototype.showTimeStep = function showTimeStep(i, callback) {
         this.currentFrame = i;
         this.sliderControl.value(i);
-	L.Util.requestAnimFrame(function do_redraw() {
+        L.Util.requestAnimFrame(function do_redraw() {
             this.redraw(callback);
-	}, this, true);
+        }, this, true);
     };
 
 

--- a/static/js/MapView.js
+++ b/static/js/MapView.js
@@ -130,7 +130,9 @@ MapView = (function($, L, Models, Config) {
     MapView.prototype.showTimeStep = function showTimeStep(i, callback) {
         this.currentFrame = i;
         this.sliderControl.value(i);
-        this.redraw(callback);
+	L.Util.requestAnimFrame(function do_redraw() {
+            this.redraw(callback);
+	}, this, true);
     };
 
 


### PR DESCRIPTION
Uses [`L.Util.requestAnimFrame`](http://leafletjs.com/reference.html#util-requestanimframe) so that redraws will only happen while the browser window is active. This has the effect of pausing animation when the browser is hidden (or switched to another tab, etc.).

Reference: http://www.paulirish.com/2011/requestanimationframe-for-smart-animating
