### PR TITLE
Avoid queuing multiple frames at once.

### DIFF
--- a/tabs/app.py
+++ b/tabs/app.py
@@ -218,10 +218,15 @@ def main(argv=sys.argv[1:]):
                         default=10, help="Decimation factor")
     parser.add_argument('-D', '--debug', action='store_true',
                         help="Debug mode")
+    parser.add_argument('--cached', action='store_true',
+                        help='Use cached data.')
 
     args = parser.parse_args(argv)
     if args.decimate:
         tc._fs_args['decimate_factor'] = args.decimate
+        del tc.fs
+    if args.cached:
+        tc._fs_args['data_uri'] = thredds_frame_source.CACHE_DATA_URI
         del tc.fs
     start(debug=args.debug, host=args.host, port=args.port)
 

--- a/tabs/static/js/MapView.js
+++ b/tabs/static/js/MapView.js
@@ -107,6 +107,7 @@ MapView = (function($, L, Models, Config) {
 
 
     MapView.prototype.mapScale = function mapScale() {
+        var self = this;
         var scale = 0.5;     // vector scaling (m/s -> degrees) at default zoom
         var zoom = this.map.getZoom();
         return scale * Math.pow(2, this.defaultZoom - zoom);
@@ -115,6 +116,7 @@ MapView = (function($, L, Models, Config) {
 
     // hard-coded region of interest outline
     MapView.prototype.addRegionOutline = function addRegionOutline() {
+        var self = this;
         var featureLayer = L.mapbox.featureLayer()
             .loadURL(this.domainURL)
             .on('ready', function(layer) {
@@ -131,6 +133,7 @@ MapView = (function($, L, Models, Config) {
 
     // update vector data at each time step
     MapView.prototype.showTimeStep = function showTimeStep(i, callback) {
+        var self = this;
         this.currentFrame = i;
         this.sliderControl.value(i);
         L.Util.requestAnimFrame(function do_redraw() {

--- a/tabs/static/js/MapView.js
+++ b/tabs/static/js/MapView.js
@@ -114,10 +114,10 @@ MapView = (function($, L, Models, Config) {
 
     MapView.prototype.toggleRunState = function toggleRunState() {
         var self = this;
-        if (self.runState === RUN_STOPPED) {
+        if (self.runState !== RUN_FOREVER) {
             self.start(RUN_FOREVER);
         } else {
-            self.stop();
+            self.start(RUN_SYNC);
         }
     };
 
@@ -214,7 +214,7 @@ MapView = (function($, L, Models, Config) {
                 if (self.runState === RUN_FOREVER) {
                     self.queueFrame();
                 } else {
-                    self.runState = RUN_STOPPED;
+                    self.stop();
                 }
             }
             setTimeout(self._run.bind(self), waitTime);

--- a/tabs/static/js/MapView.js
+++ b/tabs/static/js/MapView.js
@@ -179,7 +179,6 @@ MapView = (function($, L, Models, Config) {
         var prevState = self.runState;
         self.runState = newState === undefined ? RUN_FOREVER : newState;
         if (prevState === RUN_STOPPED) {
-            console.log('runnin!');
             self._run();
         }
     };

--- a/tabs/static/js/MapView.js
+++ b/tabs/static/js/MapView.js
@@ -208,7 +208,8 @@ MapView = (function($, L, Models, Config) {
 
 
             // XXX: Remove eventually
-            if (showFPS && ((self.currentFrame % showFPS) === 0)) {
+            var reportableFrame = (self.currentFrame % showFPS) === 0;
+            if (showFPS && self.runState === RUN_FOREVER && reportableFrame) {
                 var fps = (showFPS / ((t - self.t) / 1000))
                           .toFixed(2) + ' FPS';
                 var ms = waitTime.toFixed(0) + '/' + self.delay + 'ms';

--- a/tabs/static/js/VelocityView.js
+++ b/tabs/static/js/VelocityView.js
@@ -78,9 +78,6 @@ var VelocityView = (function($, L, Models, Config) {
                            points: points,
                            mapScale: mapView.mapScale()};
 
-            // Put the initial velocity vectors on the map
-            self.redraw();
-
         });
 
         return self;

--- a/tabs/static/js/tabs.js
+++ b/tabs/static/js/tabs.js
@@ -1,6 +1,5 @@
 var showFPS = 30;
-var mapView = MapView.mapView({isRunning: false});
-// mapView.addRegionOutline();
+var mapView = MapView.mapView({});
 if (Config.isRunning) {
     // FIXME: This can crash if frame 1 tries to load before mapView populates
     // mapView.start();

--- a/tabs/thredds_frame_source.py
+++ b/tabs/thredds_frame_source.py
@@ -18,7 +18,7 @@ from octant_lite import rot2d, shrink
 TABS_DATA_URI = 'http://barataria.tamu.edu:8080/thredds/dodsC/NcML/txla_nesting6.nc'  # noqa
 CACHE_DATA_URI = os.path.join(os.path.dirname(__file__),
                               "../static/data/txla_nesting6.nc")
-DEFAULT_DATA_URI = CACHE_DATA_URI
+DEFAULT_DATA_URI = TABS_DATA_URI
 
 
 class THREDDSFrameSource(object):


### PR DESCRIPTION
Keeping in line with the sweeping performance improvements of the last two weeks, this PR prevents multiple asynchronous requests from building up when the slider is being moved around.

I'd call it a state machine, but there wasn't really enough to map it out properly. Essentially it works like this:

1. If the slider moves, assign the current value to a variable (overwriting whatever is there) and set the system to SYNC mode. If the system was STOPPED, we start it.
2. If the space bar is pressed or the TABSControl is clicked, set the system to FOREVER mode. If the system was STOPPED, we start it.

While running, we check if the system state is STOPPED. If so, we return immediately and the loop breaks. Otherwise, we load whatever frame is currently in the variable. If we ever discover that the current frame and the variable match, we set the system to STOPPED, unless we were in FOREVER mode, at which time we set the variable to current + 1.